### PR TITLE
#8: Fixing orders synchronization

### DIFF
--- a/AvaTax.TaxModule.Data/Model/AvaCreateOrAdjustTransactionModel.cs
+++ b/AvaTax.TaxModule.Data/Model/AvaCreateOrAdjustTransactionModel.cs
@@ -1,4 +1,5 @@
 ﻿using Avalara.AvaTax.RestClient;
+using VirtoCommerce.Domain.Inventory.Services;
 using VirtoCommerce.Domain.Order.Model;
 using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Platform.Core.Common;
@@ -7,10 +8,11 @@ namespace AvaTax.TaxModule.Data.Model
 {
     public class AvaCreateOrAdjustTransactionModel : CreateOrAdjustTransactionModel
     {
-        public virtual AvaCreateOrAdjustTransactionModel FromOrder(CustomerOrder order, Store store, string companyCode)
+        public virtual AvaCreateOrAdjustTransactionModel FromOrder(CustomerOrder order, Store store, string companyCode, 
+            IFulfillmentCenterService fulfillmentCenterService)
         {
             var transaction = AbstractTypeFactory<AvaCreateTransactionModel>.TryCreateInstance();
-            transaction.FromOrder(order, store, companyCode);
+            transaction.FromOrder(order, store, companyCode, fulfillmentCenterService);
             createTransactionModel = transaction;
 
             return this;

--- a/AvaTax.TaxModule.Data/Model/AvaCreateOrAdjustTransactionModel.cs
+++ b/AvaTax.TaxModule.Data/Model/AvaCreateOrAdjustTransactionModel.cs
@@ -1,15 +1,16 @@
 ﻿using Avalara.AvaTax.RestClient;
 using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace AvaTax.TaxModule.Data.Model
 {
     public class AvaCreateOrAdjustTransactionModel : CreateOrAdjustTransactionModel
     {
-        public virtual AvaCreateOrAdjustTransactionModel FromOrder(CustomerOrder order, string companyCode)
+        public virtual AvaCreateOrAdjustTransactionModel FromOrder(CustomerOrder order, Store store, string companyCode)
         {
             var transaction = AbstractTypeFactory<AvaCreateTransactionModel>.TryCreateInstance();
-            transaction.FromOrder(order, companyCode);
+            transaction.FromOrder(order, store, companyCode);
             createTransactionModel = transaction;
 
             return this;

--- a/AvaTax.TaxModule.Data/Model/AvaCreateTransactionModel.cs
+++ b/AvaTax.TaxModule.Data/Model/AvaCreateTransactionModel.cs
@@ -76,20 +76,6 @@ namespace AvaTax.TaxModule.Data.Model
                 lines.Add(avaTaxLine);
             }
 
-            var shippingAddress = order.Addresses?.FirstOrDefault(x => x.AddressType == AddressType.Shipping);
-            if (shippingAddress != null)
-            {
-                var avaAddress = AbstractTypeFactory<AvaAddressLocationInfo>.TryCreateInstance();
-                avaAddress.FromAddress(shippingAddress);
-
-                addresses = new AddressesModel
-                {
-                    // TODO: set actual origin address (fulfillment center/store owner)?
-                    shipFrom = avaAddress,
-                    shipTo = avaAddress
-                };
-            }
-
             return this;
         }
     }

--- a/AvaTax.TaxModule.Data/Model/AvaCreateTransactionModel.cs
+++ b/AvaTax.TaxModule.Data/Model/AvaCreateTransactionModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Avalara.AvaTax.RestClient;
 using VirtoCommerce.Domain.Commerce.Model;
+using VirtoCommerce.Domain.Inventory.Services;
 using VirtoCommerce.Domain.Order.Model;
 using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Domain.Tax.Model;
@@ -50,7 +51,8 @@ namespace AvaTax.TaxModule.Data.Model
             return this;
         }
 
-        public virtual AvaCreateTransactionModel FromOrder(CustomerOrder order, Store store, string requiredCompanyCode)
+        public virtual AvaCreateTransactionModel FromOrder(CustomerOrder order, Store store, string requiredCompanyCode, 
+            IFulfillmentCenterService fulfillmentCenterService)
         {
             code = order.Number;
             customerCode = order.CustomerId;
@@ -63,14 +65,14 @@ namespace AvaTax.TaxModule.Data.Model
             foreach (var orderLine in order.Items.Where(x => !x.IsTransient()))
             {
                 var avaTaxLine = AbstractTypeFactory<AvaLineItem>.TryCreateInstance();
-                avaTaxLine.FromOrderLine(orderLine);
+                avaTaxLine.FromOrderLine(orderLine, order, store, fulfillmentCenterService);
                 lines.Add(avaTaxLine);
             }
 
             foreach (var shipment in order.Shipments ?? Enumerable.Empty<Shipment>())
             {
                 var avaTaxLine = AbstractTypeFactory<AvaLineItem>.TryCreateInstance();
-                avaTaxLine.FromOrderShipment(shipment, store);
+                avaTaxLine.FromOrderShipment(shipment, order, store, fulfillmentCenterService);
                 lines.Add(avaTaxLine);
             }
 

--- a/AvaTax.TaxModule.Data/Model/AvaCreateTransactionModel.cs
+++ b/AvaTax.TaxModule.Data/Model/AvaCreateTransactionModel.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Avalara.AvaTax.RestClient;
 using VirtoCommerce.Domain.Commerce.Model;
 using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Domain.Tax.Model;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -49,7 +50,7 @@ namespace AvaTax.TaxModule.Data.Model
             return this;
         }
 
-        public virtual AvaCreateTransactionModel FromOrder(CustomerOrder order, string requiredCompanyCode)
+        public virtual AvaCreateTransactionModel FromOrder(CustomerOrder order, Store store, string requiredCompanyCode)
         {
             code = order.Number;
             customerCode = order.CustomerId;
@@ -69,7 +70,7 @@ namespace AvaTax.TaxModule.Data.Model
             foreach (var shipment in order.Shipments ?? Enumerable.Empty<Shipment>())
             {
                 var avaTaxLine = AbstractTypeFactory<AvaLineItem>.TryCreateInstance();
-                avaTaxLine.FromOrderShipment(shipment);
+                avaTaxLine.FromOrderShipment(shipment, store);
                 lines.Add(avaTaxLine);
             }
 

--- a/AvaTax.TaxModule.Data/Model/AvaLineItem.cs
+++ b/AvaTax.TaxModule.Data/Model/AvaLineItem.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using Avalara.AvaTax.RestClient;
 using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Domain.Tax.Model;
 
 namespace AvaTax.TaxModule.Data.Model
@@ -30,14 +32,27 @@ namespace AvaTax.TaxModule.Data.Model
             return this;
         }
 
-        public virtual LineItemModel FromOrderShipment(Shipment shipment)
+        public virtual LineItemModel FromOrderShipment(Shipment shipment, Store store)
         {
             number = shipment.Id;
             itemCode = shipment.Number;
             description = shipment.ShipmentMethodCode;
-            taxCode = shipment.TaxType;
             quantity = 1;
             amount = shipment.Sum;
+
+            // First, let's try to read the tax type from the shipment itself.
+            taxCode = shipment.TaxType;
+
+            // If it is not filled, let's find the shipping method for this shipment and take the tax type from there.
+            if (string.IsNullOrEmpty(taxCode))
+            {
+                var shippingMethod = store.ShippingMethods.FirstOrDefault(x => x.Code == shipment.ShipmentMethodCode);
+                if (shippingMethod != null)
+                {
+                    taxCode = shippingMethod.TaxType;
+                }
+            }
+
             return this;
         }
     }

--- a/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
+++ b/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
@@ -9,6 +9,7 @@ using AvaTax.TaxModule.Core.Services;
 using AvaTax.TaxModule.Data.Model;
 using AvaTax.TaxModule.Web.Services;
 using Newtonsoft.Json;
+using VirtoCommerce.Domain.Inventory.Services;
 using VirtoCommerce.Domain.Order.Model;
 using VirtoCommerce.Domain.Order.Services;
 using VirtoCommerce.Domain.Search.ChangeFeed;
@@ -24,12 +25,15 @@ namespace AvaTax.TaxModule.Data.Services
 
         private readonly ICustomerOrderService _orderService;
         private readonly IStoreService _storeService;
+        private readonly IFulfillmentCenterService _fulfillmentCenterService;
         private readonly Func<IAvaTaxSettings, AvaTaxClient> _avaTaxClientFactory;
 
-        public OrdersSynchronizationService(ICustomerOrderService orderService, IStoreService storeService, Func<IAvaTaxSettings, AvaTaxClient> avaTaxClientFactory)
+        public OrdersSynchronizationService(ICustomerOrderService orderService, IStoreService storeService, 
+            IFulfillmentCenterService fulfillmentCenterService, Func<IAvaTaxSettings, AvaTaxClient> avaTaxClientFactory)
         {
             _orderService = orderService;
             _storeService = storeService;
+            _fulfillmentCenterService = fulfillmentCenterService;
             _avaTaxClientFactory = avaTaxClientFactory;
         }
 
@@ -158,7 +162,7 @@ namespace AvaTax.TaxModule.Data.Services
             if (!order.IsCancelled)
             {
                 var createOrAdjustTransactionModel = AbstractTypeFactory<AvaCreateOrAdjustTransactionModel>.TryCreateInstance();
-                createOrAdjustTransactionModel.FromOrder(order, store, companyCode);
+                createOrAdjustTransactionModel.FromOrder(order, store, companyCode, _fulfillmentCenterService);
                 var transactionModel = await avaTaxClient.CreateOrAdjustTransactionAsync(string.Empty, createOrAdjustTransactionModel);
             }
             else

--- a/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
+++ b/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using VirtoCommerce.Domain.Order.Model;
 using VirtoCommerce.Domain.Order.Services;
 using VirtoCommerce.Domain.Search.ChangeFeed;
+using VirtoCommerce.Domain.Store.Model;
 using VirtoCommerce.Domain.Store.Services;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -121,7 +122,7 @@ namespace AvaTax.TaxModule.Data.Services
                         try
                         {
                             var companyCode = avaTaxSettings.CompanyCode;
-                            await SendOrderToAvaTax(order, companyCode, avaTaxClient);
+                            await SendOrderToAvaTax(order, store, companyCode, avaTaxClient);
                         }
                         catch (AvaTaxError e)
                         {
@@ -152,12 +153,12 @@ namespace AvaTax.TaxModule.Data.Services
             progressCallback(progressInfo);
         }
 
-        protected virtual async Task SendOrderToAvaTax(CustomerOrder order, string companyCode, AvaTaxClient avaTaxClient)
+        protected virtual async Task SendOrderToAvaTax(CustomerOrder order, Store store, string companyCode, AvaTaxClient avaTaxClient)
         {
             if (!order.IsCancelled)
             {
                 var createOrAdjustTransactionModel = AbstractTypeFactory<AvaCreateOrAdjustTransactionModel>.TryCreateInstance();
-                createOrAdjustTransactionModel.FromOrder(order, companyCode);
+                createOrAdjustTransactionModel.FromOrder(order, store, companyCode);
                 var transactionModel = await avaTaxClient.CreateOrAdjustTransactionAsync(string.Empty, createOrAdjustTransactionModel);
             }
             else

--- a/AvaTax.TaxModule.Web/Scripts/blades/order-synchronization-status.tpl.html
+++ b/AvaTax.TaxModule.Web/Scripts/blades/order-synchronization-status.tpl.html
@@ -11,7 +11,7 @@
                 </div>
                 <div ng-if="blade.currentEntity.linkToAvaTax">
                     <div class="sub-t">{{ 'avaTax.blades.order-synchronization-status.labels.transaction-in-avatax' | translate }}</div>
-                    <div>{{ 'avaTax.blades.order-synchronization-status.labels.link-to-transaction' | translate }} <a ng-href="{{blade.currentEntity.linkToAvaTax}}">#{{blade.currentEntity.transactionId}}</a></div>
+                    <div>{{ 'avaTax.blades.order-synchronization-status.labels.link-to-transaction' | translate }} <a ng-href="{{blade.currentEntity.linkToAvaTax}}" target="_blank">#{{blade.currentEntity.transactionId}}</a></div>
                 </div>
                 <div class="sub-t">{{ 'avaTax.blades.order-synchronization-status.labels.raw-transaction-content' | translate }}</div>
                 <pre>{{blade.currentEntity.rawContent}}</pre>


### PR DESCRIPTION
This PR belongs to issue #8. It contains the following changes:
* Tax type for shipment line items now can be copied from the shipment method itself;
* Source and destination addresses are now assigned to each Avalara line item - this is more correct than assigning addresses to the transaction itself, because different line items can be shipped from different fulfillment centers;
* Source address for line items can now be filled from the following locations:
    * Address of the fulfillment center assigned to the line item itself;
    * Address of the default fulfillment center of the store.