### PR TITLE
Fixed 'Value cannon be null' exception

### DIFF
--- a/src/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
+++ b/src/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
@@ -84,7 +84,8 @@ namespace AvaTax.TaxModule.Data.Services
                     var joinedMessages = string.Join(Environment.NewLine, errorDetails?.details?.Select(x => $"{x.severity}: {x.message} {x.description}") ?? []);
                     var errorMessage = string.Join(Environment.NewLine, new[] { errorDetails?.code.ToString(), errorDetails?.message, joinedMessages }
                         .Where(s => !string.IsNullOrEmpty(s)));
-                    result.Errors = [errorMessage];
+
+                    result.Errors = [errorMessage.IsNullOrEmpty() ? e.Message : errorMessage];
                     result.HasErrors = true;
                 }
             }
@@ -129,8 +130,10 @@ namespace AvaTax.TaxModule.Data.Services
                         {
                             var errorDetails = e.error?.error;
                             var joinedMessages = string.Join(Environment.NewLine, errorDetails?.details?.Select(x => $"{x.severity}: {x.message} {x.description}") ?? []);
+                            joinedMessages = string.Join(Environment.NewLine, new[] { errorDetails?.code.ToString(), errorDetails?.message, joinedMessages }
+                                .Where(s => !string.IsNullOrEmpty(s)));
 
-                            var errorMessage = $"Order #{order.Number}: {errorDetails?.message}{Environment.NewLine}{joinedMessages}";
+                            var errorMessage = $"Order #{order.Number}: {(joinedMessages.IsNullOrEmpty() ? e.Message : joinedMessages)}";
                             progressInfo.Errors.Add(errorMessage);
                         }
                     }

--- a/src/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
+++ b/src/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
@@ -127,11 +127,10 @@ namespace AvaTax.TaxModule.Data.Services
                         }
                         catch (AvaTaxError e)
                         {
-                            var errorDetails = e.error.error;
-                            var joinedMessages = string.Join(Environment.NewLine,
-                                errorDetails.details.Select(x => $"{x.severity}: {x.message} {x.description}"));
+                            var errorDetails = e.error?.error;
+                            var joinedMessages = string.Join(Environment.NewLine, errorDetails?.details?.Select(x => $"{x.severity}: {x.message} {x.description}") ?? []);
 
-                            var errorMessage = $"Order #{order.Number}: {errorDetails.message}{Environment.NewLine}{joinedMessages}";
+                            var errorMessage = $"Order #{order.Number}: {errorDetails?.message}{Environment.NewLine}{joinedMessages}";
                             progressInfo.Errors.Add(errorMessage);
                         }
                     }

--- a/src/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
+++ b/src/AvaTax.TaxModule.Data/Services/OrdersSynchronizationService.cs
@@ -80,11 +80,11 @@ namespace AvaTax.TaxModule.Data.Services
                 }
                 catch (AvaTaxError e)
                 {
-                    var errorDetails = e.error.error;
-                    var joinedMessages = string.Join(Environment.NewLine, errorDetails.details.Select(x => $"{x.severity}: {x.message} {x.description}"));
-
-                    var errorMessage = $"{errorDetails.message}{Environment.NewLine}{joinedMessages}";
-                    result.Errors = new[] { errorMessage };
+                    var errorDetails = e.error?.error;
+                    var joinedMessages = string.Join(Environment.NewLine, errorDetails?.details?.Select(x => $"{x.severity}: {x.message} {x.description}") ?? []);
+                    var errorMessage = string.Join(Environment.NewLine, new[] { errorDetails?.code.ToString(), errorDetails?.message, joinedMessages }
+                        .Where(s => !string.IsNullOrEmpty(s)));
+                    result.Errors = [errorMessage];
                     result.HasErrors = true;
                 }
             }


### PR DESCRIPTION
## Description
Fixed 'Value cannon be null' exception during the processing another exception

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AvalaraTax_3.1001.0-pr-70-8791.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to exception-to-message formatting in order sync paths, adding null-safety and fallbacks without altering business flow.
> 
> **Overview**
> Prevents secondary failures when handling `AvaTaxError` exceptions during order status checks and order synchronization by making error-detail extraction null-safe.
> 
> Error messages now include available `code`/`message` plus any `details`, and fall back to `e.Message` when Avalara error payloads are missing, avoiding the prior "Value cannot be null" path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8791a53aded9348ac888bcc5d3b0077d524d7281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->